### PR TITLE
Allow for specifying path to netrc as an option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
 0.9.3-next:
  * fix option `no_verify_hostname' with more recent curl versions
+ * add option to specify netrc file path
 
 0.9.3:
  * migrate from cvs to git

--- a/doc/curlftpfs.1
+++ b/doc/curlftpfs.1
@@ -204,6 +204,10 @@ server.
 (SSL) Curlftpfs will not verify the certificate when connecting to a SSL
 enabled server.
 .TP
+.B netrc=<file>
+Specify a file to use instead of the default \fB~/.netrc\fR file for
+authentication.
+.TP
 .B pass=<password>
 (SSL) Pass phrase for the private key.
 .TP

--- a/ftpfs.c
+++ b/ftpfs.c
@@ -174,6 +174,7 @@ static struct fuse_opt ftpfs_opts[] = {
   FTPFS_OPT("codepage=%s",        codepage, 0),
   FTPFS_OPT("iocharset=%s",       iocharset, 0),
   FTPFS_OPT("nomulticonn",        multiconn, 0),
+  FTPFS_OPT("netrc=%s",           netrc, 0),
 
   FUSE_OPT_KEY("-h",             KEY_HELP),
   FUSE_OPT_KEY("--help",         KEY_HELP),
@@ -1496,6 +1497,7 @@ static void usage(const char* progname) {
 "    utf8                try to transfer file list with utf-8 encoding\n"
 "    codepage=STR        set the codepage the server uses\n"
 "    iocharset=STR       set the charset used by the client\n"
+"    netrc=STR           file to use instead of the default .netrc file\n"
 "\n"
 "CurlFtpFS cache options:  \n"
 "    cache=yes|no              enable/disable cache (default: yes)\n"
@@ -1763,6 +1765,9 @@ int main(int argc, char** argv) {
     fprintf(stderr, "Error initializing libcurl\n");
     exit(1);
   }
+
+  if (ftpfs.netrc)
+    curl_easy_setopt_or_die(easy, CURLOPT_NETRC_FILE, ftpfs.netrc);
 
   res = cache_parse_options(&args);
   if (res == -1)

--- a/ftpfs.c
+++ b/ftpfs.c
@@ -621,24 +621,6 @@ static void free_ftpfs_file(struct ftpfs_file *fh) {
   free(fh);
 }
 
-static int buffer_file(struct ftpfs_file *fh) {
-  // If we want to write to the file, we have to load it all at once,
-  // modify it in memory and then upload it as a whole as most FTP servers
-  // don't support resume for uploads.
-  pthread_mutex_lock(&ftpfs.lock);
-  cancel_previous_multi();
-  curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_URL, fh->full_path);
-  curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_WRITEDATA, &fh->buf);
-  CURLcode curl_res = curl_easy_perform(ftpfs.connection);
-  pthread_mutex_unlock(&ftpfs.lock);
-
-  if (curl_res != 0) {
-    return -EACCES;
-  }
-
-  return 0;
-}
-
 static int create_empty_file(const char * path)
 {
   int err = 0;

--- a/ftpfs.h
+++ b/ftpfs.h
@@ -67,6 +67,7 @@ struct ftpfs {
   char *codepage;
   char *iocharset;
   int multiconn;
+  char *netrc;
 };
 
 extern struct ftpfs ftpfs;


### PR DESCRIPTION
From commit message:

> This allows users to give the location to the netrc file, which often contains secrets for authentication into an FTP server.
> 
> Typically, this file lives under `$HOME/.netrc`. However, in certain scenarios it is desirable to keep this file somewhere other than the user's directory.
> 
> This is basically the same patch from https://sourceforge.net/p/curlftpfs/discussion/542749/thread/3becfed6/ which was never merged upstream.

While at it, I also removed an unused function that was breaking compilation when warnings are enforcing.